### PR TITLE
hide form container when back button is clicked - fixes #14

### DIFF
--- a/src/js/buttons.js
+++ b/src/js/buttons.js
@@ -19,7 +19,6 @@ class BackBtn {
 
     hide() {
         this.elem.classList.add('btn-back--hidden');
-        document.querySelector('.js-data-entry-container').classList.add('data-entry-container--hidden');
     }
 }
 

--- a/src/js/buttons.js
+++ b/src/js/buttons.js
@@ -5,20 +5,21 @@ class BackBtn {
         this.show = this.show.bind(this);
         this.hide = this.hide.bind(this);
         this.onClick = this.onClick.bind(this);
-        this.elem.addEventListener('click', this.onClick)
+        this.elem.addEventListener('click', this.onClick);
     }
-
+    
     onClick() {
         this.emitter.emit('show-map');
         this.hide();
     }
 
     show() {
-        this.elem.classList.remove('btn-back--hidden')
+        this.elem.classList.remove('btn-back--hidden');
     }
 
     hide() {
-        this.elem.classList.add('btn-back--hidden')
+        this.elem.classList.add('btn-back--hidden');
+        document.querySelector('.js-data-entry-container').classList.add('data-entry-container--hidden');
     }
 }
 

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -36,11 +36,10 @@ class Form {
     }
 
     hide() {
-        this.containerElem.classList.remove('data-entry-container--hidden');
+        this.containerElem.classList.add('data-entry-container--hidden');
     }
 
 }
-
 
 class RemovedBtn {
     constructor(emitter) {


### PR DESCRIPTION
Justification:

If you opened the "form container" to confirm a box, but then clicked the back button in the upper left instead of confirming/saving, the container was still present below the box. So I added a classList to the hide function that adds the `data-entry-container--hidden` class. 

Furthermore, the `hide()` function on the form was _removing_ the `data-entry-container--hidden` class instead of adding it. But maybe I'm misunderstanding something there.