### PR TITLE
Enhance styling of circles to emphasize missing post boxes

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -45,7 +45,7 @@ import Modal from './modal';
     mapboxgl.accessToken = 'pk.eyJ1IjoicnVzc2JpZ2dzIiwiYSI6ImNrZHg2am55ejE3aHYyeWtqOGtocjh4ejgifQ.Qg_LH8LUNchJZBPsqDme9g';
     const map = new mapboxgl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/streets-v11',
+        style: 'mapbox://styles/mapbox/dark-v10',
         center: [-98.5795,39.8283] ,
         zoom: 5 ,
         hash: true
@@ -126,6 +126,17 @@ import Modal from './modal';
                             [22, 180]
                         ]
                     }
+                },
+                layout: {
+                    'circle-sort-key': [
+                        'match',
+                        ['get', 'status'],
+                        'removed',
+                        2,
+                        'present',
+                        1,
+                        0
+                    ]
                 }
             });
 
@@ -142,9 +153,19 @@ import Modal from './modal';
             'source-layer': 'collection_box_trim_valid-0tbyft',
             paint: {
                 'circle-color': '#004B87',
+                'circle-opacity': [
+                    'interpolate',
+                    ['linear'],
+                    ['zoom'],
+                    2,
+                    0.3,
+                    14,
+                    0.9
+                    ],
                 'circle-radius': {
                     'base': 4,
                     'stops': [
+                        [2, 2],
                         [9, 4],
                         [12, 6],
                         [16, 15],

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -45,7 +45,7 @@ import Modal from './modal';
     mapboxgl.accessToken = 'pk.eyJ1IjoicnVzc2JpZ2dzIiwiYSI6ImNrZHg2am55ejE3aHYyeWtqOGtocjh4ejgifQ.Qg_LH8LUNchJZBPsqDme9g';
     const map = new mapboxgl.Map({
         container: 'map',
-        style: 'mapbox://styles/mapbox/dark-v10',
+        style: 'mapbox://styles/mapbox/streets-v11',
         center: [-98.5795,39.8283] ,
         zoom: 5 ,
         hash: true
@@ -106,7 +106,7 @@ import Modal from './modal';
                 'removed',
                 '#FF0000',
                 'present',
-                '#008000',
+                '#23d100',
                 '#004B87'
             ]
 
@@ -116,16 +116,15 @@ import Modal from './modal';
                 'source': 'collection-box-surveyed-src',
                 paint: {
                     'circle-color': expression,
-                    'circle-radius': {
-                        'base': 4,
-                        'stops': [
-                            [9, 4],
-                            [12, 6],
-                            [16, 15],
-                            [18, 30],
-                            [22, 180]
-                        ]
-                    }
+                    'circle-radius': [
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        4, 1,
+                        9, 3,
+                        14, 6,
+                        18, 30
+                    ]
                 },
                 layout: {
                     'circle-sort-key': [
@@ -152,27 +151,34 @@ import Modal from './modal';
             'source': 'collection-box-src',
             'source-layer': 'collection_box_trim_valid-0tbyft',
             paint: {
-                'circle-color': '#004B87',
-                'circle-opacity': [
-                    'interpolate',
-                    ['linear'],
-                    ['zoom'],
-                    2,
-                    0.3,
-                    14,
-                    0.9
-                    ],
-                'circle-radius': {
-                    'base': 4,
-                    'stops': [
-                        [2, 2],
-                        [9, 4],
-                        [12, 6],
-                        [16, 15],
-                        [18, 30],
-                        [22, 180]
-                    ]
-                }
+                'circle-stroke-color': '#004B87',
+                'circle-stroke-width': [
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    4, 0.1,
+                    9, 0.5,
+                    14, 1,
+                    16, 4
+                ],
+                'circle-stroke-opacity': [
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    4, 0.6,
+                    7, 0.8,
+                    14, 0.9
+                ],
+                'circle-opacity': 0,
+                'circle-radius': [
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    4, 1,
+                    9, 3,
+                    14, 6,
+                    18, 30
+                ]
             }
         });
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,16 @@
 
 import mitt from 'mitt';
 
- import Form from './form';
+import Form from './form';
 import {BackBtn} from './buttons';
 import Snack from './snack';
 import Modal from './modal';
+
+const colors = {
+    present: '#004B87',
+    removed: '#d7191c',
+    inoperable: '#fdae61'
+}
 
 {
     const emitter = mitt();
@@ -107,7 +113,7 @@ import Modal from './modal';
             'source': 'collection-box-src',
             'source-layer': 'collection_box_trim_valid-0tbyft',
             paint: {
-                'circle-stroke-color': '#004B87',
+                'circle-stroke-color': colors.present,
                 'circle-stroke-width': [
                     "interpolate",
                     ["linear"],
@@ -130,8 +136,7 @@ import Modal from './modal';
                     "interpolate",
                     ["linear"],
                     ["zoom"],
-                    4, 1,
-                    9, 3,
+                    10, 1,
                     14, 6,
                     18, 30
                 ]
@@ -151,10 +156,10 @@ import Modal from './modal';
                 'match',
                 ['get', 'status'],
                 'removed',
-                '#FF0000',
-                'present',
-                '#23d100',
-                '#004B87'
+                colors.removed,
+                'inoperable',
+                colors.inoperable,
+                colors.present
             ]
 
             map.addLayer({

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -47,7 +47,8 @@ import Modal from './modal';
         container: 'map',
         style: 'mapbox://styles/mapbox/streets-v11',
         center: [-98.5795,39.8283] ,
-        zoom: 5
+        zoom: 5 ,
+        hash: true
     });
 
     function setMapLocation(position) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -93,53 +93,9 @@ import Modal from './modal';
     }
   
     map.on('load', function() {
-        fetch('https://spot-the-box.s3.amazonaws.com/reports.json').then(res => res.json()).then(data=> {
 
-            map.addSource('collection-box-surveyed-src', {
-                type: 'geojson',
-                data: data
-            });
+        // USPS postbox locations
 
-            const expression = [
-                'match',
-                ['get', 'status'],
-                'removed',
-                '#FF0000',
-                'present',
-                '#23d100',
-                '#004B87'
-            ]
-
-            map.addLayer({
-                'id': 'collection-boxes-surveyed',
-                'type': 'circle',
-                'source': 'collection-box-surveyed-src',
-                paint: {
-                    'circle-color': expression,
-                    'circle-radius': [
-                        "interpolate",
-                        ["linear"],
-                        ["zoom"],
-                        4, 1,
-                        9, 3,
-                        14, 6,
-                        18, 30
-                    ]
-                },
-                layout: {
-                    'circle-sort-key': [
-                        'match',
-                        ['get', 'status'],
-                        'removed',
-                        2,
-                        'present',
-                        1,
-                        0
-                    ]
-                }
-            });
-
-        });
         map.addSource('collection-box-src', {
             type: 'vector',
             url: 'mapbox://mikelmaron.3ws9y5k1'
@@ -181,6 +137,56 @@ import Modal from './modal';
                 ]
             }
         });
+
+        // Surveyed postbox locations
+
+        fetch('https://spot-the-box.s3.amazonaws.com/reports.json').then(res => res.json()).then(data=> {
+
+            map.addSource('collection-box-surveyed-src', {
+                type: 'geojson',
+                data: data
+            });
+
+            const expression = [
+                'match',
+                ['get', 'status'],
+                'removed',
+                '#FF0000',
+                'present',
+                '#23d100',
+                '#004B87'
+            ]
+
+            map.addLayer({
+                'id': 'collection-boxes-surveyed',
+                'type': 'circle',
+                'source': 'collection-box-surveyed-src',
+                paint: {
+                    'circle-color': expression,
+                    'circle-radius': [
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        7, 4,
+                        14, 6,
+                        18, 30
+                    ]
+                },
+                layout: {
+                    'circle-sort-key': [
+                        'match',
+                        ['get', 'status'],
+                        'removed',
+                        2,
+                        'present',
+                        1,
+                        0
+                    ]
+                }
+            });
+
+        });
+
 
         map.on('mouseenter', 'collection-boxes-surveyed', function() {
             map.getCanvas().style.cursor = 'pointer';

--- a/src/scss/_legend.scss
+++ b/src/scss/_legend.scss
@@ -25,11 +25,12 @@
             width: 10px;
 
             &.legend-item-box {
-                background-color: $postal-blue;   
+                border: 1px solid $postal-blue; 
+                background-color: transparent;   
             }
 
             &.legend-item-present {
-                background-color: green;   
+                background-color: #23d100;   
             }
 
             &.legend-item-removed {

--- a/src/scss/_legend.scss
+++ b/src/scss/_legend.scss
@@ -30,15 +30,15 @@
             }
 
             &.legend-item-present {
-                background-color: #23d100;   
+                background-color: $postal-blue;   
             }
 
             &.legend-item-removed {
-                background-color: red;   
+                background-color: #d7191c;   
             }
 
             &.legend-item-inoperable {
-                background-color: darkorange;   
+                background-color: #fdae61;   
             }
         }
     }


### PR DESCRIPTION
Includes a few enhancements to bring the focus of the map to missing boxes.

- Change basemap style to dark to give more focus to overlay data points
- Reduce the size of unserveyed locations when zoomed out to emphasize the collected data
- Sort the surveyed circles to ensure missing boxes are drawn on top of existing ones. 
- Adds a url hash parameter to allow permalinking to a location

![_Screen4](https://user-images.githubusercontent.com/126868/90719565-c2337700-e282-11ea-9b8b-38140568de20.gif)
